### PR TITLE
Fix some documentation woes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ local cjson = require "cjson"
 local project_id = os.getenv("SUPABASE_PROJECT_ID")
 local public_anon_key = os.getenv("SUPABASE_PUBLIC_ANON_KEY")
 local service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-local api_base_url = "https://" .. project_id .. ".supabase.co/rest/v1/"
+local api_base_url = "https://" .. project_id .. ".supabase.co/rest/v1"
 local auth_headers = {apikey = public_anon_key, authorization = "Bearer " .. service_role_key}
 local supabase = Database:new(api_base_url, auth_headers)
 local todos = supabase:from("todos"):select():execute()
@@ -65,8 +65,8 @@ Injecting a JSON library:
 
 ```lua
 local lunajson = require "lunajson"
-database:set_json_implementation(lunajson)
-local todos = database:from("todos"):select():execute()
+Database:set_json_implementation(lunajson)
+local todos = Database:from("todos"):select():execute()
 ```
 
 Insert:
@@ -87,13 +87,13 @@ QueryBuilder:select{"column1", "column2"}
 Horizontal filtering:
 
 ```lua
-database:from("todos"):select():filter{id__eq = 1}:execute()
+Database:from("todos"):select():filter{id__eq = 1}:execute()
 -- or alternatively
-database:from("todos"):select():filter{id = 1}:execute()
+Database:from("todos"):select():filter{id = 1}:execute()
 -- or alternatively
-database:from("todos"):select():filter("id=eq.1"):execute()
+Database:from("todos"):select():filter("id=eq.1"):execute()
 -- we also support the `in` operator using tables:
-database:from("todos"):select():filter{id__in = {1, 2, 3}}:execute()
+Database:from("todos"):select():filter{id__in = {1, 2, 3}}:execute()
 ```
 
 Same goes for other operators described in the PostgREST documentation:
@@ -103,13 +103,13 @@ Updates:
 
 ```lua
 local values = {done = true, task = "learn lua"}
-database:from("todos"):update(values):execute()
+Database:from("todos"):update(values):execute()
 ```
 
 Delete:
 
 ```lua
-database:from("todos"):delete():filter{id = 4}:execute()
+Database:from("todos"):delete():filter{id = 4}:execute()
 ```
 
 ## Logger
@@ -120,7 +120,7 @@ It's possible to log the requests to the REST API by using a logger callback.
 function request_logger(method, url, payload, headers)
     print("method: " .. method .. " url: " .. url)
 end
-database.request_logger = request_logger
+Database.request_logger = request_logger
 ```
 
 ## Development


### PR DESCRIPTION
I'm using this for a Love2D project and ran into some troubles that took me a little bit of debugging to figure out.

It was nothing to do with the implementation itself but the example in the readme; the extra slash in `api_base_url` causes all select to 404 as it's looking at `rest/v1//{tableName}` rather than `rest/v1/{tableName}`. In addition, the initial declaration of `Database` in the example uses an uppercase D (as I believe it should as an object) but later usage in the readme uses a lowercase `database`.

Two small fixes to the readme that will resolve any confusion for new users.